### PR TITLE
JSON Serialization Error

### DIFF
--- a/Jabbot/Bot.cs
+++ b/Jabbot/Bot.cs
@@ -8,7 +8,7 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Web.Hosting;
 using Jabbot.Models;
-using Jabbot.Sprockets;
+using Jabbot.Sprockets.Core;
 using SignalR.Client.Hubs;
 
 namespace Jabbot
@@ -369,7 +369,7 @@ namespace Jabbot
 
         private void Send(string command)
         {
-            _chat.Invoke("send", command).Wait();
+            _chat.Invoke("send", command, null).Wait();
         }
     }
 }


### PR DESCRIPTION
When attempting to naively connect to a Jabbr server (either fresh clone,
or jabbr.net), an http 500 error is thrown. Investigating it on local, it
appeared to be a problem in JSON deserialization. within Newtonsoft.Json
library I would consistently get "Error parsing comment. Expected: *, got
n. Line 1, position 1." or similar, depending on which command I was
attempting to issue.

Looking at the Signalr.Client sources, it appears that the command (like
"/help") was the only parameter being passed through to the _hub.Invoke
arg array which in turn means that it was the only thing being populated
into the json "data" element. When I investigated what is returned via
the Jabbr client, there are additional elements sent in this JSON object
- specifically "id" and "room". Assuming that the id was a generated
  message GUID, I sent a freshly generate Guid through as well, and it
  was successful.

Initially I wrapped the "command" argument in an anonymous type which
includes a new Guid, and all worked, but I'm not sure if some commands
would fail to function because of this.

I picked up from the JabbR.Client repository that the IHubProxy.Invoke is
being called with the addition of a null parameter. When I add this second
parameter, it works just the same. I have gone for this second solution,
as it appears to be closer to the intended API behaviour.
